### PR TITLE
Allow passing of Google Cloud Credentials from settings

### DIFF
--- a/django_cloud_tasks/apps.py
+++ b/django_cloud_tasks/apps.py
@@ -1,8 +1,6 @@
 from django.apps import AppConfig
 from django.conf import settings
 
-from .connection import connection
-
 
 class DCTConfig(AppConfig):
     name = 'django_cloud_tasks'
@@ -38,3 +36,7 @@ class DCTConfig(AppConfig):
     @classmethod
     def handler_secret(cls):
         return getattr(settings, 'DJANGO_CLOUD_TASKS_HANDLER_SECRET', None)
+
+    @classmethod
+    def google_cloud_credentials(cls):
+        return getattr(settings, 'DJANGO_CLOUD_TASKS_CREDENTIALS', None)

--- a/django_cloud_tasks/connection.py
+++ b/django_cloud_tasks/connection.py
@@ -1,5 +1,7 @@
 import googleapiclient.discovery
 
+from .apps import DCTConfig
+
 
 class cached_property(object):
     def __init__(self, fget):
@@ -17,7 +19,8 @@ class cached_property(object):
 class GoogleCloudClient(object):
     @cached_property
     def client(self):
-        client = googleapiclient.discovery.build('cloudtasks', 'v2beta3')
+        client = googleapiclient.discovery.build('cloudtasks', 'v2beta3',
+                credentials=DCTConfig.google_cloud_credentials())
         return client
 
     @cached_property


### PR DESCRIPTION
Allow users to define Google Cloud credentials in their settings file and use them with the API Discovery service.

Users will need to use either the application default credentials or credentials generated from a service account file.

Application default credentials:
```python
import google.auth

credentials, project = google.auth.default()

# django_cloud_tasks settings
DJANGO_CLOUD_TASKS_CREDENTIALS = credentials
```

From a service account file:
```python
# obtain a servicxe account file from your Google Cloud Project:
# https://console.cloud.google.com/apis/credentials
# then add the Cloud Tasks admin permission
# and finally download the file as json

from google.oauth2 import service_account

credentials = service_account.Credentials.from_service_account_file(
    '/path/to/key.json')

# django_cloud_tasks settings
DJANGO_CLOUD_TASKS_CREDENTIALS = credentials
```