### PR TITLE
Update cache argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,25 @@ Installation
         )
 
 
-(3) Add configuration to your settings
+(3) Optionally, set up Google Cloud credentials in your settings.py for use with Django Cloud Tasks. If you are using a service account, make sure the account has the "Cloud Tasks Admin" permission.
+
+    .. code-block:: python
+
+        # install these if they are not already installed
+        import google.auth
+        from google.oauth2 import service_account
+
+        # ...
+
+        # To use application default credentials:
+        google_cloud_credentials, project = google.auth.default()
+
+        # To use a service account JSON file:
+        google_cloud_credentials = service_account.Credentials.from_service_account_file(
+                '/path/to/key.json')
+
+
+(4) Add configuration to your settings
 
     .. code-block:: python
 
@@ -64,8 +82,13 @@ Installation
         # the queue. Useful for debugging. Default: True
         DJANGO_CLOUD_TASKS_BLOCK_REMOTE_TASKS = False
 
+        # Optional argument. Specify a google.auth.credentials.Credentials object to use with the API 
+        # Discovery service. Can be application default credentials or credentials generated from a 
+        # service account JSON file. Default: None
+        DJANGO_CLOUD_TASKS_CREDENTIALS = None # or google_cloud_credentials if you defined this above
 
-(4) Add cloud task views to your urls.py (must resolve to the same url as ``task_handler_root_url``)
+
+(5) Add cloud task views to your urls.py (must resolve to the same url as ``task_handler_root_url``)
 
     .. code-block:: python
 

--- a/django_cloud_tasks/connection.py
+++ b/django_cloud_tasks/connection.py
@@ -1,6 +1,24 @@
 import googleapiclient.discovery
+from cachetools import Cache
 
 from .apps import DCTConfig
+
+
+class MemoryCache(Cache):
+    """
+    In-memory cache for use with API Discovery service.
+
+    Fixes https://github.com/googleapis/google-api-python-client/issues/325
+
+    Solution is from https://github.com/googleapis/google-api-python-client/issues/325#issuecomment-274349841
+    """
+    _CACHE = {}
+
+    def get(self, url):
+        return MemoryCache._CACHE.get(url)
+
+    def set(self, url, content):
+        MemoryCache._CACHE[url] = content
 
 
 class cached_property(object):
@@ -20,7 +38,8 @@ class GoogleCloudClient(object):
     @cached_property
     def client(self):
         client = googleapiclient.discovery.build('cloudtasks', 'v2beta3',
-                credentials=DCTConfig.google_cloud_credentials())
+                credentials=DCTConfig.google_cloud_credentials(), 
+                cache=MemoryCache())
         return client
 
     @cached_property

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'google-api-python-client>=1.6.4',
+        'cachetools>=4.0.0',
     ],
     license="MIT",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
     include_package_data=True,
     install_requires=[
         'google-api-python-client>=1.6.4',
-        'cachetools>=4.0.0',
     ],
     license="MIT",
     zip_safe=False,


### PR DESCRIPTION
Add our own cache to the API Discovery service to avoid errors with oauth2client.

See https://github.com/googleapis/google-api-python-client/issues/325

Solution used: https://github.com/googleapis/google-api-python-client/issues/325#issuecomment-419387788